### PR TITLE
Fix wrong directory in babel script.

### DIFF
--- a/quokka/babel/babel.bat
+++ b/quokka/babel/babel.bat
@@ -1,1 +1,1 @@
-pybabel extract -F babel.ini -k _gettext -k _ngettext -k lazy_gettext -o quokka.pot --project quokka ..\quokka
+pybabel extract -F babel.ini -k _gettext -k _ngettext -k lazy_gettext -o quokka.pot --project quokka ..

--- a/quokka/babel/babel.sh
+++ b/quokka/babel/babel.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-pybabel extract -F babel.ini -k _gettext -k _ngettext -k lazy_gettext -o quokka.pot --project quokka ../quokka
+pybabel extract -F babel.ini -k _gettext -k _ngettext -k lazy_gettext -o quokka.pot --project quokka ..


### PR DESCRIPTION
Then we can just "cd babel; bash babel.sh".
