### PR TITLE
Hide channels behind roles 

### DIFF
--- a/quokka/core/admin/views.py
+++ b/quokka/core/admin/views.py
@@ -72,7 +72,7 @@ class ChannelAdmin(ModelAdmin):
                       'show_in_menu', 'indexable']
     column_searchable_list = ('title', 'description')
     form_columns = ['title', 'slug', 'content_format', 'description',
-                    'parent', 'is_homepage',
+                    'parent', 'is_homepage', 'roles',
                     'include_in_rss', 'indexable', 'show_in_menu', 'order',
                     'per_page', 'tags', 'sort_by',
                     'published', 'canonical_url', 'values', 'channel_type',

--- a/quokka/core/models.py
+++ b/quokka/core/models.py
@@ -218,6 +218,7 @@ class Channel(Tagged, HasCustomValue, Publishable, LongSlugged,
     description = db.StringField()
     show_in_menu = db.BooleanField(default=False)
     is_homepage = db.BooleanField(default=False)
+    roles = db.ListField(db.ReferenceField('Role', reverse_delete_rule=db.PULL))
     include_in_rss = db.BooleanField(default=True)
     indexable = db.BooleanField(default=True)
     canonical_url = db.StringField()

--- a/quokka/core/views.py
+++ b/quokka/core/views.py
@@ -9,6 +9,8 @@ from flask.views import MethodView
 from quokka.utils.atom import AtomFeed
 from quokka.core.models import Channel, Content, Config
 from quokka.core.templates import render_template
+from quokka.utils import get_current_user
+
 
 logger = logging.getLogger()
 
@@ -52,6 +54,28 @@ class ContentList(MethodView):
         mpath = ",{0},".format(mpath)
 
         channel = Channel.objects.get_or_404(mpath=mpath, published=True)
+
+        user = get_current_user()
+        
+        
+        if channel.roles:
+            forbidden = True
+            for role in user.roles:
+                if role in channel.roles:
+                    forbidden = False
+                    break  # break in first occurence
+        else:
+            forbidden = False
+
+            
+        if forbidden:
+            return abort('Access Denied') # or redirect
+
+        
+        
+        
+        
+
 
         # if channel.is_homepage and request.path != "/":
         #     return redirect("/")

--- a/quokka/settings.py
+++ b/quokka/settings.py
@@ -17,7 +17,7 @@ Import it if you want to pass some password to your configs.
 """
 DB for localhost
 """
-MONGODB_SETTINGS = {'DB': "servicedirectory"}
+MONGODB_SETTINGS = {'DB': "quokka_db"}
 
 """
 DB in remote host

--- a/quokka/settings.py
+++ b/quokka/settings.py
@@ -17,7 +17,7 @@ Import it if you want to pass some password to your configs.
 """
 DB for localhost
 """
-MONGODB_SETTINGS = {'DB': "quokka_db"}
+MONGODB_SETTINGS = {'DB': "servicedirectory"}
 
 """
 DB in remote host

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ Flask-Babel
 Flask-Bcrypt
 Flask-Gravatar
 Flask-OAuthlib
-https://github.com/majorz/flask-htmlbuilder/tarball/master
+https://github.com/quokkaproject/flask-htmlbuilder/tarball/master
 Flask-Login<0.2.7
 Flask-Principal
 Flask-Mail


### PR DESCRIPTION
Hi Bruno,

thanks for your complete code. Yesterday I built it in.

The included code snippets now allow to control every channel with a corresponding role.

Features:
1. In Admin-Mode a channel has now an input field where you can add a role to a channel
2. the role will be saved in Mongo-DB
3. if a channel has no role it will be displayed to everybody
4. if a user has a role which is mentioned in the channel the channel (and content) will be displayed
5. IF NOT: the user will be logout AND redirected to channel redirect_url ("/" by default)

Bruno, if you like the code merge it with the master of your branch.

Greetings from Germany, always nice to work with you,

Henner
