### PR TITLE
Added #89: flask-weasyprint

### DIFF
--- a/quokka/ext/__init__.py
+++ b/quokka/ext/__init__.py
@@ -12,7 +12,7 @@ from quokka.modules.accounts.models import Role, User
 
 from . import (generic, babel, blueprints, error_handlers, context_processors,
                template_filters, before_request, views, themes, fixtures,
-               oauthlib)
+               oauthlib, weasyprint)
 
 
 class Security(_Security):
@@ -38,6 +38,9 @@ def configure_extensions(app, admin):
 
     blueprints.load_from_packages(app)
     blueprints.load_from_folder(app)
+
+    # enable .pdf support for posts
+    weasyprint.configure(app)
 
     configure_admin(app, admin)
 

--- a/quokka/ext/weasyprint.py
+++ b/quokka/ext/weasyprint.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+import logging
+import collections
+
+from flask import url_for
+
+
+logger = logging.getLogger()
+
+try:
+    from flask_weasyprint import render_pdf, HTML
+
+    import_error = False
+except (ImportError, OSError) as e:
+
+    print ("""
+    Error importing flask-weasyprint!
+    PDF support is temporarily disabled.
+    Manual dependencies may need to be installed.
+    See,
+        `http://weasyprint.org/docs/install/#by-platform`_
+        `https://github.com/Kozea/WeasyPrint/issues/79`_
+
+    """ + e.message)
+
+    import_error = True
+
+
+def configure(app):
+    # only configure .pdf extension if it's enabled
+    # and configured correctly in the environment.
+    if app.config.get('ENABLE_TO_PDF', False) and not import_error:
+
+        def render_to_pdf(long_slug):
+            return render_pdf(url_for('detail', long_slug=long_slug))
+
+        app.add_url_rule('/<path:long_slug>.pdf', view_func=render_to_pdf)

--- a/quokka/ext/weasyprint.py
+++ b/quokka/ext/weasyprint.py
@@ -1,15 +1,12 @@
 # -*- coding: utf-8 -*-
 
 import logging
-import collections
-
 from flask import url_for
-
 
 logger = logging.getLogger()
 
 try:
-    from flask_weasyprint import render_pdf, HTML
+    from flask_weasyprint import render_pdf
 
     import_error = False
 except (ImportError, OSError) as e:

--- a/quokka/settings.py
+++ b/quokka/settings.py
@@ -118,6 +118,14 @@ python manage.py collectstatic to copy to main static folder
 """
 COLLECT_STATIC_ROOT = STATIC_ROOT
 
+
+"""
+Activates Flask-Weasyprint extension
+so that Posts can be rendered to PDF just by
+changing the extension from .html to .pdf
+"""
+ENABLE_TO_PDF = True
+
 """
 Never change it here, use local_settings for this.
 """

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ Flask-Cache
 flask-admin
 flask-babelex
 flask-debugtoolbar
+flask-weasyprint
 dealer
 flask-collect
 flake8


### PR DESCRIPTION
Added the ability to render a detail view (`quokka.core.views.ContentDetail`) as PDF by changing the extension from `.html` to `.pdf`
