### PR TITLE
Fixing template file for security reset_password 

### DIFF
--- a/quokka/templates/security/reset_password.html
+++ b/quokka/templates/security/reset_password.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends theme("base.html") %}
 
 {% block content %}
 

--- a/quokka/themes/default/templates/security/reset_password.html
+++ b/quokka/themes/default/templates/security/reset_password.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends theme("base.html") %}
 
 {% block content %}
 


### PR DESCRIPTION
The base.html was being called directly without theme(), which was causing template to be all messy.
