### PR TITLE
This PR should fix #261

### DIFF
--- a/quokka/core/admin/__init__.py
+++ b/quokka/core/admin/__init__.py
@@ -14,8 +14,8 @@ from .views import (IndexView, InspectorView, LinkAdmin, ConfigAdmin,
                     SubContentPurposeAdmin, ChannelTypeAdmin,
                     ContentTemplateTypeAdmin, ChannelAdmin)
 
-from .utils import _, _l, _n
-
+# from .utils import _, _l, _n
+from quokka.utils.translation import _, _l, _n
 '''
 _n is here only for backwards compatibility, to be imported by 3rd party
 modules. The below _n below is to avoid pep8 error
@@ -91,8 +91,8 @@ def configure_admin(app, admin):
                 FileAdmin(
                     entry['path'],
                     entry['url'],
-                    name=entry['name'],
-                    category=entry['category'],
+                    name=_l(entry['name']),
+                    category=_l(entry['category']),
                     endpoint=entry['endpoint'],
                     roles_accepted=entry.get('roles_accepted'),
                     editable_extensions=entry.get('editable_extensions')
@@ -119,7 +119,7 @@ def configure_admin(app, admin):
                     "/_themes/{0}/".format(theme.identifier),
                     name="{0}: {1} static files".format(suffix,
                                                         theme.identifier),
-                    category="Files",
+                    category=_l("Files"),
                     endpoint="{0}_static_files".format(theme.identifier),
                     roles_accepted=('admin', "editor"),
                     editable_extensions=app.config.get(
@@ -132,7 +132,7 @@ def configure_admin(app, admin):
                     "/theme_template_files/{0}/".format(theme.identifier),
                     name="{0}: {1} template files".format(suffix,
                                                           theme.identifier),
-                    category="Files",
+                    category=_l("Files"),
                     endpoint="{0}_template_files".format(theme.identifier),
                     roles_accepted=('admin', "editor"),
                     editable_extensions=app.config.get(
@@ -143,7 +143,7 @@ def configure_admin(app, admin):
             pass
 
     # adding views
-    admin.add_view(InspectorView(category=_("Settings"),
+    admin.add_view(InspectorView(category=_l("Settings"),
                                  name=_l("Inspector")))
 
     # adding extra views
@@ -151,7 +151,7 @@ def configure_admin(app, admin):
     for view in extra_views:
         admin.add_view(
             import_string(view['module'])(
-                category=_(view.get('category')),
+                category=_l(view.get('category')),
                 name=_l(view.get('name'))
             )
         )
@@ -160,25 +160,25 @@ def configure_admin(app, admin):
     admin.register(
         Link,
         LinkAdmin,
-        category=_("Content"),
+        category=_l("Content"),
         name=_l("Link")
     )
     admin.register(Config,
                    ConfigAdmin,
-                   category=_("Settings"),
+                   category=_l("Settings"),
                    name=_l("Config"))
     admin.register(SubContentPurpose,
                    SubContentPurposeAdmin,
-                   category=_("Settings"),
+                   category=_l("Settings"),
                    name=_l("Sub content purposes"))
     admin.register(ChannelType, ChannelTypeAdmin,
-                   category=_("Settings"), name=_l("Channel type"))
+                   category=_l("Settings"), name=_l("Channel type"))
     admin.register(ContentTemplateType,
                    ContentTemplateTypeAdmin,
-                   category=_("Settings"),
+                   category=_l("Settings"),
                    name=_l("Template type"))
     admin.register(Channel, ChannelAdmin,
-                   category=_("Content"), name=_l("Channel"))
+                   category=_l("Content"), name=_l("Channel"))
 
     # avoid registering twice
     if admin.app is None:

--- a/quokka/core/admin/__init__.py
+++ b/quokka/core/admin/__init__.py
@@ -15,7 +15,7 @@ from .views import (IndexView, InspectorView, LinkAdmin, ConfigAdmin,
                     ContentTemplateTypeAdmin, ChannelAdmin)
 
 # from .utils import _, _l, _n
-from quokka.utils.translation import _, _l, _n
+from quokka.utils.translation import _l, _n
 '''
 _n is here only for backwards compatibility, to be imported by 3rd party
 modules. The below _n below is to avoid pep8 error

--- a/quokka/ext/babel.py
+++ b/quokka/ext/babel.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # from flask import request, session
-from flask.ext.babelex import Babel
+from flask.ext.babelex import Babel, Domain
 
 babel = Babel()
 
@@ -21,3 +21,7 @@ def configure(app):
     #     return request.accept_languages.best_match(
     #         app.config['BABEL_LANGUAGES'])
     # babel.localeselector(get_locale)
+domain = Domain()
+_l = domain.lazy_gettext
+_ = domain.gettext
+_n = domain.ngettext

--- a/quokka/ext/babel.py
+++ b/quokka/ext/babel.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # from flask import request, session
-from flask.ext.babelex import Babel, Domain
+from flask.ext.babelex import Babel
 
 babel = Babel()
 

--- a/quokka/ext/babel.py
+++ b/quokka/ext/babel.py
@@ -21,7 +21,3 @@ def configure(app):
     #     return request.accept_languages.best_match(
     #         app.config['BABEL_LANGUAGES'])
     # babel.localeselector(get_locale)
-domain = Domain()
-_l = domain.lazy_gettext
-_ = domain.gettext
-_n = domain.ngettext

--- a/quokka/modules/accounts/admin.py
+++ b/quokka/modules/accounts/admin.py
@@ -2,10 +2,9 @@
 from wtforms.fields import TextField
 from wtforms.widgets import PasswordInput
 from quokka import admin
-from quokka.core.admin import _, _l
 from quokka.core.admin.models import ModelAdmin
 from .models import Role, User, Connection
-
+from quokka.ext.babel import _, _l
 
 class UserAdmin(ModelAdmin):
     roles_accepted = ('admin',)
@@ -33,7 +32,6 @@ class RoleAdmin(ModelAdmin):
     roles_accepted = ('admin',)
     column_list = ('name', 'description')
 
-
-admin.register(User, UserAdmin, category=_("Accounts"), name=_l("User"))
-admin.register(Role, RoleAdmin, category=_("Accounts"), name=_l("Roles"))
-admin.register(Connection, category=_("Accounts"), name=_l("Connection"))
+admin.register(User, UserAdmin, category=_l('Accounts'), name=_l("User"))
+admin.register(Role, RoleAdmin, category=_l('Accounts'), name=_l("Roles"))
+admin.register(Connection, category=_l('Accounts'), name=_l("Connection"))

--- a/quokka/modules/accounts/admin.py
+++ b/quokka/modules/accounts/admin.py
@@ -4,7 +4,7 @@ from wtforms.widgets import PasswordInput
 from quokka import admin
 from quokka.core.admin.models import ModelAdmin
 from .models import Role, User, Connection
-from quokka.ext.babel import _, _l
+from quokka.utils.translation import _, _l
 
 class UserAdmin(ModelAdmin):
     roles_accepted = ('admin',)

--- a/quokka/modules/accounts/admin.py
+++ b/quokka/modules/accounts/admin.py
@@ -4,7 +4,8 @@ from wtforms.widgets import PasswordInput
 from quokka import admin
 from quokka.core.admin.models import ModelAdmin
 from .models import Role, User, Connection
-from quokka.utils.translation import _, _l
+from quokka.utils.translation import _l
+
 
 class UserAdmin(ModelAdmin):
     roles_accepted = ('admin',)

--- a/quokka/modules/comments/admin.py
+++ b/quokka/modules/comments/admin.py
@@ -5,7 +5,8 @@ from quokka import admin
 from quokka.core.admin.models import ModelAdmin
 from quokka.core.widgets import TextEditor
 from .models import Comment
-from quokka.utils.translation import _, _l
+from quokka.utils.translation import _l
+
 
 class CommentAdmin(ModelAdmin):
     roles_accepted = ('admin', 'editor', 'moderator')

--- a/quokka/modules/comments/admin.py
+++ b/quokka/modules/comments/admin.py
@@ -5,7 +5,7 @@ from quokka import admin
 from quokka.core.admin.models import ModelAdmin
 from quokka.core.widgets import TextEditor
 from .models import Comment
-from quokka.ext.babel import _, _l
+from quokka.utils.translation import _, _l
 
 class CommentAdmin(ModelAdmin):
     roles_accepted = ('admin', 'editor', 'moderator')

--- a/quokka/modules/comments/admin.py
+++ b/quokka/modules/comments/admin.py
@@ -2,11 +2,10 @@
 
 
 from quokka import admin
-from quokka.core.admin import _, _l
 from quokka.core.admin.models import ModelAdmin
 from quokka.core.widgets import TextEditor
 from .models import Comment
-
+from quokka.ext.babel import _, _l
 
 class CommentAdmin(ModelAdmin):
     roles_accepted = ('admin', 'editor', 'moderator')
@@ -20,5 +19,5 @@ class CommentAdmin(ModelAdmin):
     }
 
 
-admin.register(Comment, CommentAdmin, category=_('Content'),
+admin.register(Comment, CommentAdmin, category=_l('Content'),
                name=_l("Comments"))

--- a/quokka/modules/media/admin.py
+++ b/quokka/modules/media/admin.py
@@ -6,7 +6,6 @@ from jinja2 import Markup
 
 from quokka import admin
 from quokka.utils import lazy_str_setting
-from quokka.core.admin import _, _l
 from quokka.core.models import Channel
 from quokka.core.admin.models import ModelAdmin
 from quokka.core.admin.fields import ImageUploadField
@@ -15,6 +14,7 @@ from quokka.core.admin.models import BaseContentAdmin
 from quokka.core.widgets import TextEditor, PrepopulatedText
 from .models import Image, File, Video, Audio, MediaGallery
 from quokka.core.admin.ajax import AjaxModelLoader
+from quokka.ext.babel import _, _l
 
 
 class MediaAdmin(ModelAdmin):
@@ -148,10 +148,10 @@ class MediaGalleryAdmin(BaseContentAdmin):
         'slug': {'widget': PrepopulatedText(master='title')}
     }
 
-
-admin.register(File, FileAdmin, category=_('Media'), name=_l("File"))
-admin.register(Video, VideoAdmin, category=_('Media'), name=_l("Video"))
-admin.register(Audio, AudioAdmin, category=_('Media'), name=_l("Audio"))
-admin.register(Image, ImageAdmin, category=_('Media'), name=_l("Image"))
+    
+admin.register(File, FileAdmin, category=_l('Media'), name=_l("File"))
+admin.register(Video, VideoAdmin, category=_l('Media'), name=_l("Video"))
+admin.register(Audio, AudioAdmin, category=_l('Media'), name=_l("Audio"))
+admin.register(Image, ImageAdmin, category=_l('Media'), name=_l("Image"))
 admin.register(MediaGallery, MediaGalleryAdmin,
-               category=_('Content'), name=_l("Media Gallery"))
+               category=_l('Content'), name=_l("Media Gallery"))

--- a/quokka/modules/media/admin.py
+++ b/quokka/modules/media/admin.py
@@ -14,7 +14,7 @@ from quokka.core.admin.models import BaseContentAdmin
 from quokka.core.widgets import TextEditor, PrepopulatedText
 from .models import Image, File, Video, Audio, MediaGallery
 from quokka.core.admin.ajax import AjaxModelLoader
-from quokka.ext.babel import _, _l
+from quokka.utils.translation import _, _l
 
 
 class MediaAdmin(ModelAdmin):

--- a/quokka/modules/media/admin.py
+++ b/quokka/modules/media/admin.py
@@ -14,7 +14,7 @@ from quokka.core.admin.models import BaseContentAdmin
 from quokka.core.widgets import TextEditor, PrepopulatedText
 from .models import Image, File, Video, Audio, MediaGallery
 from quokka.core.admin.ajax import AjaxModelLoader
-from quokka.utils.translation import _, _l
+from quokka.utils.translation import _l
 
 
 class MediaAdmin(ModelAdmin):
@@ -148,7 +148,7 @@ class MediaGalleryAdmin(BaseContentAdmin):
         'slug': {'widget': PrepopulatedText(master='title')}
     }
 
-    
+
 admin.register(File, FileAdmin, category=_l('Media'), name=_l("File"))
 admin.register(Video, VideoAdmin, category=_l('Media'), name=_l("Video"))
 admin.register(Audio, AudioAdmin, category=_l('Media'), name=_l("Audio"))

--- a/quokka/modules/posts/admin.py
+++ b/quokka/modules/posts/admin.py
@@ -3,8 +3,8 @@
 from quokka import admin
 from quokka.core.admin.models import BaseContentAdmin
 from quokka.core.widgets import TextEditor, PrepopulatedText
-from quokka.core.admin import _, _l
 from .models import Post
+from quokka.ext.babel import _, _l
 
 
 class PostAdmin(BaseContentAdmin):
@@ -23,4 +23,4 @@ class PostAdmin(BaseContentAdmin):
     }
 
 
-admin.register(Post, PostAdmin, category=_("Content"), name=_l("Post"))
+admin.register(Post, PostAdmin, category=_l('Content'), name=_l("Post"))

--- a/quokka/modules/posts/admin.py
+++ b/quokka/modules/posts/admin.py
@@ -4,7 +4,7 @@ from quokka import admin
 from quokka.core.admin.models import BaseContentAdmin
 from quokka.core.widgets import TextEditor, PrepopulatedText
 from .models import Post
-from quokka.ext.babel import _, _l
+from quokka.utils.translation import _, _l
 
 
 class PostAdmin(BaseContentAdmin):

--- a/quokka/modules/posts/admin.py
+++ b/quokka/modules/posts/admin.py
@@ -4,7 +4,7 @@ from quokka import admin
 from quokka.core.admin.models import BaseContentAdmin
 from quokka.core.widgets import TextEditor, PrepopulatedText
 from .models import Post
-from quokka.utils.translation import _, _l
+from quokka.utils.translation import _l
 
 
 class PostAdmin(BaseContentAdmin):

--- a/quokka/translations/zh_CN/LC_MESSAGES/messages.po
+++ b/quokka/translations/zh_CN/LC_MESSAGES/messages.po
@@ -242,6 +242,47 @@ msgstr "账户"
 msgid "Roles"
 msgstr "角色"
 
+msgid "User"
+msgstr "用户"
+
 msgid "Connection"
 msgstr "连接"
 
+msgid "Video"
+msgstr "视频"
+
+msgid "Audio"
+msgstr "音频"
+
+msgid "Image"
+msgstr "图像"
+
+msgid "Post"
+msgstr "文章"
+
+msgid "Comments"
+msgstr "评论"
+
+msgid "Link"
+msgstr "链接"
+
+msgid "Channel"
+msgstr "频道"
+
+msgid "Media Gallery"
+msgstr "媒体展览"
+
+msgid "Files"
+msgstr "文件"
+
+msgid "Inspector"
+msgstr "审查"
+
+msgid "Sub content purposes"
+msgstr "子内容意图"
+
+msgid "Channel type"
+msgstr "频道类型"
+
+msgid "Template type"
+msgstr "模板类型"

--- a/quokka/translations/zh_CN/LC_MESSAGES/messages.po
+++ b/quokka/translations/zh_CN/LC_MESSAGES/messages.po
@@ -1,0 +1,247 @@
+# Chinese (Simplified, China) translations for quokka.
+# Copyright (C) 2015 ORGANIZATION
+# This file is distributed under the same license as the quokka project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: quokka VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2015-07-17 13:31+0800\n"
+"PO-Revision-Date: 2015-07-17 13:32+0800\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: zh_Hans_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 1.3\n"
+
+#: ../core/admin/__init__.py:146 ../core/admin/__init__.py:168
+#: ../core/admin/__init__.py:172 ../core/admin/__init__.py:175
+#: ../core/admin/__init__.py:178
+msgid "Settings"
+msgstr "设置"
+
+#: ../core/admin/__init__.py:163 ../core/admin/__init__.py:181
+#: ../modules/comments/admin.py:23 ../modules/media/admin.py:157
+#: ../modules/posts/admin.py:26
+msgid "Content"
+msgstr "内容"
+
+#: ../core/admin/models.py:139
+#, python-format
+msgid "Item not found %(i)s"
+msgstr "第%(i)s项未找到"
+
+#: ../core/admin/models.py:165
+msgid "You can select only one item for this action"
+msgstr ""
+
+#: ../modules/media/admin.py:152 ../modules/media/admin.py:153
+#: ../modules/media/admin.py:154 ../modules/media/admin.py:155
+msgid "Media"
+msgstr "多媒体"
+
+#: ../themes/cosmo/templates/admin/actions.html:2
+msgid "With selected"
+msgstr "选择"
+
+#: ../themes/cosmo/templates/admin/index.html:9
+msgid "Latest Posts"
+msgstr "最近的文章"
+
+#: ../themes/cosmo/templates/admin/index.html:16
+msgid "Edit"
+msgstr "编辑"
+
+#: ../themes/cosmo/templates/admin/index.html:18
+msgid "View"
+msgstr "浏览"
+
+#: ../themes/cosmo/templates/admin/index.html:21
+msgid "There is no content yet!"
+msgstr "什么都没有"
+
+#: ../themes/cosmo/templates/admin/index.html:21
+msgid "Create a new post"
+msgstr "建立新帖子"
+
+#: ../themes/cosmo/templates/admin/index.html:27
+msgid "Latest Comments"
+msgstr "最近的评论"
+
+#: ../themes/cosmo/templates/admin/index.html:31
+msgid "says"
+msgstr "说"
+
+#: ../themes/cosmo/templates/admin/index.html:40
+msgid "No comments yet!"
+msgstr "无评论"
+
+#: ../themes/cosmo/templates/admin/index.html:41
+msgid ""
+"Internal comment system is enabled, if you want to change it click in "
+"config button and change from 'internal' to 'disqus' in comments "
+"configuration and set your disqus_script."
+msgstr "内部评论系统开发，你可以通过配置按钮改为disqus"
+
+#: ../themes/cosmo/templates/admin/index.html:49
+msgid "New Post"
+msgstr "新文章"
+
+#: ../themes/cosmo/templates/admin/index.html:50
+msgid "Posts"
+msgstr "文章"
+
+#: ../themes/cosmo/templates/admin/index.html:52
+msgid "Config"
+msgstr "配置"
+
+#: ../themes/cosmo/templates/admin/index.html:53
+msgid "Users"
+msgstr "用户"
+
+#: ../themes/cosmo/templates/admin/index.html:55
+msgid "Images"
+msgstr "图片"
+
+#: ../themes/cosmo/templates/admin/index.html:56
+msgid "New Image"
+msgstr "新图片"
+
+#: ../themes/cosmo/templates/admin/index.html:58
+msgid "File"
+msgstr "文件"
+
+#: ../themes/cosmo/templates/admin/index.html:59
+msgid "New File"
+msgstr "新文件"
+
+#: ../themes/cosmo/templates/admin/lib.html:151
+msgid "Submit"
+msgstr "提交"
+
+#: ../themes/cosmo/templates/admin/lib.html:156
+msgid "Cancel"
+msgstr "取消"
+
+#: ../themes/cosmo/templates/admin/file/edit.html:5
+#, python-format
+msgid "You are editing %(path)s"
+msgstr "你正在编辑%(path)s"
+
+#: ../themes/cosmo/templates/admin/file/list.html:9
+msgid "Root"
+msgstr "根"
+
+#: ../themes/cosmo/templates/admin/file/list.html:67
+#, python-format
+msgid "Are you sure you want to delete \\'%(name)s\\' recursively?"
+msgstr "你确定要完全删除%(name)s?"
+
+#: ../themes/cosmo/templates/admin/file/list.html:75
+#, python-format
+msgid "Are you sure you want to delete \\'%(name)s\\'?"
+msgstr "你确定要完全删除%(name)s?"
+
+#: ../themes/cosmo/templates/admin/file/list.html:110
+msgid "Upload File"
+msgstr "上传文件"
+
+#: ../themes/cosmo/templates/admin/file/list.html:115
+msgid "Create Directory"
+msgstr "创建目录"
+
+#: ../themes/cosmo/templates/admin/file/list.html:132
+msgid "Please select at least one file."
+msgstr "请选择至少一个文件"
+
+#: ../themes/cosmo/templates/admin/file/rename.html:5
+#, python-format
+msgid "Please provide new name for %(name)s"
+msgstr "请提供新的名字，为%(name)s"
+
+#: ../themes/cosmo/templates/admin/model/create.html:5
+msgid "Save and add another"
+msgstr "保存并继续添加"
+
+#: ../themes/cosmo/templates/admin/model/create.html:17
+#: ../themes/cosmo/templates/admin/model/list.html:16
+msgid "List"
+msgstr "列表"
+
+#: ../themes/cosmo/templates/admin/model/create.html:20
+#: ../themes/cosmo/templates/admin/model/list.html:20
+msgid "Create"
+msgstr "创建"
+
+#: ../themes/cosmo/templates/admin/model/edit.html:5
+msgid "Save and continue editing"
+msgstr "保存并继续编辑"
+
+#: ../themes/cosmo/templates/admin/model/inline_list_base.html:10
+msgid "Delete?"
+msgstr "删除?"
+
+#: ../themes/cosmo/templates/admin/model/inline_list_base.html:33
+msgid "Add"
+msgstr "添加"
+
+#: ../themes/cosmo/templates/admin/model/layout.html:3
+msgid "Add Filter"
+msgstr "添加过滤"
+
+#: ../themes/cosmo/templates/admin/model/layout.html:17
+msgid "Apply"
+msgstr "应用"
+
+#: ../themes/cosmo/templates/admin/model/layout.html:19
+msgid "Reset Filters"
+msgstr "重新设置过滤"
+
+#: ../themes/cosmo/templates/admin/model/layout.html:30
+msgid "Remove Filter"
+msgstr "移除过滤"
+
+#: ../themes/cosmo/templates/admin/model/layout.html:69
+#: ../themes/cosmo/templates/admin/model/layout.html:76
+msgid "Search"
+msgstr "搜索"
+
+#: ../themes/cosmo/templates/admin/model/list.html:20
+msgid "Create new record"
+msgstr "创建新记录"
+
+#: ../themes/cosmo/templates/admin/model/list.html:56
+msgid "Select all records"
+msgstr "选择所有记录"
+
+#: ../themes/cosmo/templates/admin/model/list.html:67
+#: ../themes/cosmo/templates/admin/model/list.html:76
+#, python-format
+msgid "Sort by %(name)s"
+msgstr "按%(name)s排序"
+
+#: ../themes/cosmo/templates/admin/model/list.html:98
+msgid "Select record"
+msgstr "选择记录"
+
+#: ../themes/cosmo/templates/admin/model/list.html:114
+msgid "You sure you want to delete this item?"
+msgstr "你确定要删除？"
+
+#: ../themes/cosmo/templates/admin/model/list.html:151
+msgid "Please select at least one model."
+msgstr "请选择至少一个模型"
+
+# 
+msgid "Accounts"
+msgstr "账户"
+
+msgid "Roles"
+msgstr "角色"
+
+msgid "Connection"
+msgstr "连接"
+

--- a/quokka/utils/translation.py
+++ b/quokka/utils/translation.py
@@ -1,6 +1,6 @@
 from flask import g
 from babel.support import LazyProxy
-from flask.ext.babelex import Domain
+from flask.ext.babelex import gettext, lazy_gettext, ngettext
 
 # from quokka.utils.translations import ugettext_lazy as _
 
@@ -13,7 +13,6 @@ def ugettext(s):
 
 ugettext_lazy = LazyProxy(ugettext)
 
-domain = Domain()
-_l = domain.lazy_gettext
-_ = domain.gettext
-_n = domain.ngettext
+_ = gettext
+_l = lazy_gettext
+_n = ngettext

--- a/quokka/utils/translation.py
+++ b/quokka/utils/translation.py
@@ -1,5 +1,6 @@
 from flask import g
 from babel.support import LazyProxy
+from flask.ext.babelex import Domain
 
 # from quokka.utils.translations import ugettext_lazy as _
 
@@ -11,3 +12,8 @@ def ugettext(s):
     return g.translations.ugettext(s)
 
 ugettext_lazy = LazyProxy(ugettext)
+
+domain = Domain()
+_l = domain.lazy_gettext
+_ = domain.gettext
+_n = domain.ngettext

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,8 @@ regex==2015.7.12
 requests==2.7.0
 requests-oauthlib==0.5.0
 simplejson==3.7.3
-speaklater==1.3
+#speaklater==1.3
+git+git://github.com/realli/speaklater.git
 Unidecode==0.4.18
 webassets==0.10.1
 Werkzeug==0.10.4


### PR DESCRIPTION
Change quokka scoped translations related function(`_, _l, _n`) to use the ones imported from `flask.ext.babelex`. That will use a default `Domain`. And `flask-admin` will still use its own `CustomDomain`.
Also added a zh_CN translation .po file.

By the way, in template files, you just use `_gettext`, and this function is introduced by `flask-admin`, which in turn will use `flask-admin`'s `Domain`. Code from `flask.ext.admin.base`:

```
def render(self, template, **kwargs)
    .....
    .....
    kwargs['_gettext'] = babel.gettext
    kwargs['_ngettext'] = babel.ngettext
    kwargs['h'] = h

    # Contribute extra arguments
    kwargs.update(self._template_args)

    return render_template(template, **kwargs)
```

And I think it's OK to use `gettext` function, which is set by `flask.ext.babelex` when `babel.init_app()` is invoked. You may still want to use `_gettext` if you want to use the `flask-adimn`'s `Domain`.

And to make `admin.register(Post, PostAdmin, category=_l('Content'), name=_l("Post"))` work, the object `_l` returned (a `_LazyString`), should implements its `__hash__` method (`flask-admin` will use it as a key in dict). I created PR to mitsuhiko/speaklater, but haven't got respond, so I just change the requirement.txt to use my repo temporarily.

It's my pleasure to contribute to an open-source project! :laughing: 
