### PR TITLE
ConfirmRegisterFrom should be same with the RegisterForm

### DIFF
--- a/quokka/ext/security.py
+++ b/quokka/ext/security.py
@@ -17,4 +17,5 @@ class ExtendedRegisterForm(RegisterForm):
 
 def init_app(app, db):
     app.security = Security(app, MongoEngineUserDatastore(db, User, Role),
-                            register_form=ExtendedRegisterForm)
+                            register_form=ExtendedRegisterForm,
+                            confirm_register_form=ExtendedRegisterForm)

--- a/quokka/themes/default/templates/security/_menu.html
+++ b/quokka/themes/default/templates/security/_menu.html
@@ -26,7 +26,7 @@
         {% endif %}
 
         {% if security.confirmable %}
-            <a class="btn btn-primary navbar-btn" xhref="{{ url_for_security('send_confirmation', **request.args) }}">Confirm account</a>
+            <a class="btn btn-primary navbar-btn" href="{{ url_for_security('send_confirmation', **request.args) }}">Confirm account</a>
         {% endif %}
     </div>
 </nav>


### PR DESCRIPTION
If we set `SECURITY_CONFIRMABLE = True`, Then in the register page, quokka will render `security/register_user.html`, but pass  a `ConfirmRegisterFrom` as the `register_user_form`.

This PR make the `ConfirmRegisterForm` use the same form as `RegisterForm`. And `RegisterForm` is  a subclass of `ConfirmRegisterForm`, I think that's totally ok. 
