### PR TITLE
Mention initial copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Licensed under MIT license. http://opensource.org/licenses/MIT
 
-Copyright (c) 2015 Quokka Project. and other contributors
+Copyright (c) 2013-2016 Quokka Project. and other contributors
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
I am not a lawyer but according to http://www.copyright.gov/circs/circ01.pdf (See screenshot of relevant section below) , listing the first year of publication in the copyright is a good thing

![selection_008](https://cloud.githubusercontent.com/assets/829526/12409934/7021c3a6-be95-11e5-8d1a-18f6948571e0.png)
