### PR TITLE
bugfix: the macro render_pagination lacks a div end tag

### DIFF
--- a/quokka/themes/pure/templates/_helpers.html
+++ b/quokka/themes/pure/templates/_helpers.html
@@ -406,5 +406,5 @@ tagged {% for tag in content.tags%}<a class="post-category post-category-design"
         </div>
     </div>
     {% endif %}
-
+</div>
 {% endmacro %}


### PR DESCRIPTION
It seems that the macro render_pagination lacks a div end tag